### PR TITLE
Update for compatibility with JSON API 8.x-1.0-beta1

### DIFF
--- a/addon/adapter.js
+++ b/addon/adapter.js
@@ -17,12 +17,6 @@ export default DS.JSONAPIAdapter.extend({
     return entity + '/' + bundle;
   },
 
-  buildQuery(snapshot) {
-    let query = this._super(...arguments);
-    query._format = 'api_json';
-    return query;
-  },
-
   query(store, type, query) {
     let drupalQuery = { filter: {} },
         queryFields = Object.keys(query),

--- a/addon/adapter.js
+++ b/addon/adapter.js
@@ -7,7 +7,7 @@ const {
 } = Ember;
 
 export default DS.JSONAPIAdapter.extend({
-  namespace: 'api',
+  namespace: 'jsonapi',
   drupalMapper: service(),
 
   pathForType(modelName) {
@@ -40,7 +40,6 @@ export default DS.JSONAPIAdapter.extend({
       query = this.sortQueryParams(drupalQuery);
     }
 
-    query._format = 'api_json';
     return this.ajax(url, 'GET', { data: query });
   },
 });


### PR DESCRIPTION
Some minor changes to make things compatible with the latest Drupal module release out-of-the-box: change API namespace from "api" to "jsonapi", don't add "_format=api_json" query parameter any longer