### PR TITLE
Payload keys (JSON API types) should be mapped when possible

### DIFF
--- a/addon/adapter.js
+++ b/addon/adapter.js
@@ -17,12 +17,6 @@ export default DS.JSONAPIAdapter.extend({
     return entity + '/' + bundle;
   },
 
-  buildQuery(snapshot) {
-    let query = this._super(...arguments);
-    query._format = 'api_json';
-    return query;
-  },
-
   query(store, type, query) {
     let drupalQuery = { filter: {} },
         queryFields = Object.keys(query),

--- a/addon/adapter.js
+++ b/addon/adapter.js
@@ -7,7 +7,7 @@ const {
 } = Ember;
 
 export default DS.JSONAPIAdapter.extend({
-  namespace: 'api',
+  namespace: 'jsonapi',
   drupalMapper: service(),
 
   pathForType(modelName) {
@@ -40,7 +40,6 @@ export default DS.JSONAPIAdapter.extend({
       query = this.sortQueryParams(drupalQuery);
     }
 
-    query._format = 'api_json';
     return this.ajax(url, 'GET', { data: query });
   },
 });

--- a/addon/serializer.js
+++ b/addon/serializer.js
@@ -27,12 +27,23 @@ const DrupalJSONAPISerializer = JSONAPISerializer.extend({
   },
 
   modelNameFromPayloadKey(key) {
-    let parts = key.split('--');
+    const parts = key.split('--');
     if (parts.length === 2) {
-      let bundle = parts[1];
-      return singularize(normalizeModelName(bundle));
+      const entity = parts[0];
+      const bundle = parts[1];
+      return this.get('drupalMapper').modelNameFor(entity, bundle) || singularize(normalizeModelName(bundle));
     }
     return singularize(normalizeModelName(key));
+  },
+
+  payloadKeyFromModelName(modelName) {
+    const drupalMapper = this.get('drupalMapper');
+    if (drupalMapper.isMapped(modelName)) {
+      const entity = drupalMapper.entityFor(modelName);
+      const bundle = drupalMapper.bundleFor(modelName);
+      return `${entity}--${bundle}`;
+    }
+    return modelName;
   },
 
   extractAttributes(modelClass, resourceHash) {

--- a/addon/services/drupal-mapper.js
+++ b/addon/services/drupal-mapper.js
@@ -32,5 +32,21 @@ export default Service.extend({
       return DRUPAL_FIELD_PREFIX + underscore(fieldName);
     }
     return underscore(fieldName);
+  },
+
+  isMapped(modelName) {
+    return this.map.hasOwnProperty(modelName);
+  },
+
+  modelNameFor(entity, bundle) {
+    return Object.keys(this.map).find(modelName => {
+      const modelMap = this.map[modelName];
+      modelMap.entity = modelMap.entity || 'node';
+
+      const bundleMatches = modelMap.bundle === bundle || modelMap.bundle === undefined && modelName === bundle;
+      if (bundleMatches && modelMap.entity === entity) {
+        return true;
+      }
+    });
   }
 });


### PR DESCRIPTION
Use the drupal-mapper service to translate JSON API "type" keys to/from model names